### PR TITLE
Include tinyg library

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "grunt-mocha-test": "~0.12.7",
     "grunt-npm-install": "^0.2.0",
     "grunt-simple-mocha": "0.4.0",
+    "tinyg": "0.3.27",
     "mathjs": "2.4.1",
     "mocha": "2.1.0",
     "should": "5.0.1",


### PR DESCRIPTION
Adding the library dependency for the tinyg driver.  Not sure if you want this to be optional or just how you want to do it.  But this version of the tinyg driver (with the updated serialport library) will install on raspberrypi just fine.
